### PR TITLE
fix(backend): handle empty export

### DIFF
--- a/apps/backend/src/core/table/exportor/csv.exportor.ts
+++ b/apps/backend/src/core/table/exportor/csv.exportor.ts
@@ -3,11 +3,15 @@ import { IRecordExportor, type Records, type Table } from '@undb/core'
 
 export class CSVExportor implements IRecordExportor {
   export(table: Table, viewId: string, data: Records): string {
+    if (data.length === 0) {
+      const view = table.mustGetView(viewId)
+      return table
+        .getOrderedFields(view, false)
+        .map((f) => f.name.value)
+        .join(',')
+    }
     const values = data.map((record) => record.toHuman(table, viewId, record.displayValues?.values))
-
     const parser = new Parser()
-    const csv = parser.parse(values)
-
-    return csv
+    return parser.parse(values)
   }
 }

--- a/apps/backend/src/core/table/exportor/excel.exportor.ts
+++ b/apps/backend/src/core/table/exportor/excel.exportor.ts
@@ -5,7 +5,10 @@ export class ExcelExportor implements IRecordExportor {
   export(table: Table, viewId: string, data: Records): Buffer {
     const values = data.map((record) => record.toHuman(table, viewId, record.displayValues?.values))
     const wb = XLSX.utils.book_new()
-    const xlsxData = XLSX.utils.json_to_sheet(values, { header: Object.keys(values[0]) })
+    const view = table.mustGetView(viewId)
+    const xlsxData = XLSX.utils.json_to_sheet(values, {
+      header: table.getOrderedFields(view, false).map((f) => f.name.value),
+    })
     XLSX.utils.book_append_sheet(wb, xlsxData, table.name.value)
     return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' })
   }


### PR DESCRIPTION
- In existing version, exporting empty content causes errors. This PR is to handle that by exporting the header (current visible fields) if there is no data. closes: #1177