### PR TITLE
feat(frontend): add cursor pointer for data type buttons

### DIFF
--- a/apps/frontend/src/lib/table/ToggleDisplayType.svelte
+++ b/apps/frontend/src/lib/table/ToggleDisplayType.svelte
@@ -38,7 +38,7 @@
 			custom
 		>
 			<div
-				class="grid h-7 w-7 place-items-center rounded p-1 duration-300 hover:bg-gray-100 text-gray-400 peer-checked:bg-gray-100 peer-checked:border-gray-600 peer-checked:text-gray-600 hover:text-gray-500"
+				class="grid h-7 w-7 place-items-center rounded p-1 duration-300 hover:bg-gray-100 text-gray-400 peer-checked:bg-gray-100 peer-checked:border-gray-600 peer-checked:text-gray-600 hover:text-gray-500 cursor-pointer"
 			>
 				<ViewIcon type={displayType} />
 			</div>


### PR DESCRIPTION
Just add `cursor-pointer` to data type buttons to indicate they are clickable.

![image](https://github.com/undb-xyz/undb/assets/35857179/76b97742-8064-4985-a3bb-ceea6c502cc1)
